### PR TITLE
To fix the problem of see always first image

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -91,6 +91,11 @@ function addItem(item, _index, _thumbSize){
     
     itemView.applyProperties(itemViewOpts);
     
+    // BUG: cannot apply not legacy properties with applyProperties, so do it now manually or index will be lost
+    // Ti.API.info('final Item: ' + JSON.stringify(itemView));
+    itemView._image = item.image;
+	itemView._index = index;
+
     if (options.showTitle){
         
         var titleView = Ti.UI.createView({


### PR DESCRIPTION
To fix the problem of see always first image when clicking. Index was lost because applyProperties()